### PR TITLE
Some proposals for the ML sim chart

### DIFF
--- a/mojaloop-simulator/.gitignore
+++ b/mojaloop-simulator/.gitignore
@@ -1,0 +1,3 @@
+# This way you can maintain a values-test.yaml in this repo for testing your changes to the chart,
+# without accidentally including it in a packaged chart.
+values-test.yaml

--- a/mojaloop-simulator/.helmignore
+++ b/mojaloop-simulator/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+# This way you can maintain a values-test.yaml in this repo for testing your changes to the chart,
+# without accidentally including it in a packaged chart.
+values-test.yaml

--- a/mojaloop-simulator/templates/_helpers.tpl
+++ b/mojaloop-simulator/templates/_helpers.tpl
@@ -1,28 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "mojaloop-simulator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "mojaloop-simulator.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.

--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -21,15 +21,15 @@ spec:
       - host: {{ $host }}
         http:
           paths:
-          - path: /sim/{{ $name }}/outbound{{ if $.Values.ingress.modernIngressController }}{{ $.Values.ingress.modernIngressControllerRegex }}{{ end }}
+          - path: /sim/{{ $name }}/outbound{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
               serviceName: sim-{{ $name }}-scheme-adapter
               servicePort: outboundapi
-          - path: /sim/{{ $name }}/inbound{{ if $.Values.ingress.modernIngressController }}{{ $.Values.ingress.modernIngressControllerRegex }}{{ end }}
+          - path: /sim/{{ $name }}/inbound{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
               serviceName: sim-{{ $name }}-scheme-adapter
               servicePort: inboundapi
-          - path: /sim/{{ $name }}/test{{ if $.Values.ingress.modernIngressController }}{{ $.Values.ingress.modernIngressControllerRegex }}{{ end }}
+          - path: /sim/{{ $name }}/test{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
               serviceName: sim-{{ $name }}-backend
               servicePort: testapi

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -114,12 +114,12 @@ defaultProbes: &defaultProbes
 
 ingress:
   annotations: {}
-  # Set this to true if you're using nginx ingress controller >= v0.22.0.
+  # If you're using nginx ingress controller >= v0.22.0 set this to (/|$)(.*).
+  # If you're using nginx ingress controller < v0.22.0 set this to an empty string.
   # This affects the way your rewrite target will work.
   # For more information see "Breaking changes" here:
   # https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220
-  modernIngressController: true
-  modernIngressControllerRegex: (/|$)(.*)
+  ingressPathRewriteRegex: (/|$)(.*)
 
 # If you enable JWS validation and intend to communicate via a switch you will almost certainly
 # want to put your switch JWS public key in this array. The name of the property in this object


### PR DESCRIPTION
Remove unused templates

Update ingress path rewrite configuration to reduce redundant configurability

Add .gitignore and .helmigonre to enable a chart developer to maintain a values-test.yaml file
inside this directory without accidentally packaging or committing it.